### PR TITLE
Warn user if venv cannot be found in default location

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ GRANT ALL ON orion.* TO 'orion'@'localhost';
 FLUSH PRIVILEGES;
 ```
 
-Get the source code and bootstrap the application:
+Get the source code and bootstrap the application. 
+
+Note that the virtual environment is located in a folder `env` 
+inside the repository root.
 
 ```bash
 $ git clone https://github.com/LINKIWI/orion-server.git

--- a/orion.wsgi
+++ b/orion.wsgi
@@ -1,6 +1,9 @@
 import os
 import site
 import sys
+import logging
+
+ENV_DIR = "env"
 
 # Set current working directory
 here = os.path.dirname(os.path.abspath(__file__))
@@ -8,11 +11,18 @@ os.chdir(here)
 sys.path.insert(0, here)
 
 # Add the virtualenv's site-packages
-site.addsitedir(os.path.join(here, 'env/local/lib/python2.7/site-packages'))
+site.addsitedir(os.path.join(here, ENV_DIR, 'local/lib/python2.7/site-packages'))
 
 # Activate the virtualenv
-activate_env = os.path.join(here, 'env/bin/activate_this.py')
-execfile(activate_env, dict(__file__=activate_env))
+activate_env = os.path.join(here, ENV_DIR, 'bin/activate_this.py')
+try:
+    execfile(activate_env, dict(__file__=activate_env))
+except IOError:
+    logging.error("""Orion expects a virtual Python environment in the folder
+    `{}/{}`. You can change the ENV_DIR
+    variable in `./orion.wsgi` if your environment is located in a different
+    folder.""".format(here, ENV_DIR))
+    raise
 
 from orion.app import create_app
 

--- a/orion.wsgi
+++ b/orion.wsgi
@@ -1,9 +1,9 @@
+import logging
 import os
 import site
 import sys
-import logging
 
-ENV_DIR = "env"
+ENV_DIR = 'env'
 
 # Set current working directory
 here = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
I added a note to the readme and a warning if the venv cannot be found.

Note that there also does not exist a directory `local/lib/python2.7/site-packages` within my virtual environment. This path is used in `orion.wsgi` line 14. I only have `lib/python2.7/site-packages`. Doesn't seem to break anything for me though.