### PR TITLE
handle reportLocation cmd

### DIFF
--- a/orion/handlers/publish_handler.py
+++ b/orion/handlers/publish_handler.py
@@ -20,6 +20,11 @@ class PublishHandler(BaseHandler):
     path = '/api/publish'
 
     def run(self, *args, **kwargs):
+        # Sometimes the client tries to send a reportLocation cmd. If server
+        # responds with non-200, all further location updates get backed up behind it.
+        # Handle with empty 200 response
+        if self.data['_type'] == 'cmd' and self.data['action'] == 'reportLocation':
+            return self.success(status=200)
         if self.data['_type'] != 'location':
             return self.error(status=400, message='Not a location publish.')
 

--- a/orion/handlers/publish_handler.py
+++ b/orion/handlers/publish_handler.py
@@ -25,6 +25,7 @@ class PublishHandler(BaseHandler):
         # Handle with empty 200 response
         if self.data['_type'] == 'cmd' and self.data['action'] == 'reportLocation':
             return self.success(status=200)
+
         if self.data['_type'] != 'location':
             return self.error(status=400, message='Not a location publish.')
 

--- a/test/handlers/test_publish_handler.py
+++ b/test/handlers/test_publish_handler.py
@@ -78,3 +78,19 @@ class TestPublishHandler(TestCase):
             self.assertEqual(location.latitude, 1.0)
             self.assertEqual(location.longitude, 2.0)
             self.assertEqual(location.address, 'address')
+
+    def test_reportLocation_action_valid_ios(self):
+        mock_data = {
+            '_type': 'cmd',
+            'action': 'reportLocation',
+            'topic': 'owntracks/user/device'
+        }
+
+        with self.mock_app.test_request_context():
+            handler = PublishHandler(ctx=self.mock_ctx, data=mock_data)
+            resp, status = handler.run()
+
+            self.assertTrue(resp['success'])
+            self.assertEqual(status, 200)
+            self.assertEqual(resp['message'], None)
+            self.assertEqual(resp['data'], {})

--- a/test/handlers/test_publish_handler.py
+++ b/test/handlers/test_publish_handler.py
@@ -79,7 +79,7 @@ class TestPublishHandler(TestCase):
             self.assertEqual(location.longitude, 2.0)
             self.assertEqual(location.address, 'address')
 
-    def test_reportLocation_action_valid_ios(self):
+    def test_cmd_report_location(self):
         mock_data = {
             '_type': 'cmd',
             'action': 'reportLocation',
@@ -92,5 +92,3 @@ class TestPublishHandler(TestCase):
 
             self.assertTrue(resp['success'])
             self.assertEqual(status, 200)
-            self.assertEqual(resp['message'], None)
-            self.assertEqual(resp['data'], {})


### PR DESCRIPTION
I ran into an issue where my ios device kept getting a 400 response from the orion server. It turns out it was sending a command like
```
{'action': 'reportLocation', 'topic': 'owntracks/user/device/cmd', '_type': 'cmd'}
```
The server was responding with `status=400, message='Not a location publish.'` and all the actual location publishes seem to have backed up behind this. Once I set the server to response with a `200`, it started flushing the backed up location publishes