### PR TITLE
WIP : Add a Dockerfile directly in the project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-buster
+FROM python:2.7-stretch
 MAINTAINER Kevin Lin <developer@kevinlin.info>
 
 RUN pip install gunicorn

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:2.7.16-slim
+MAINTAINER Kevin Lin <developer@kevinlin.info>
+
+RUN apt-get update && apt-get install -y wget unzip python-dev default-libmysqlclient-dev gcc build-essential && pip install -r requirements.txt && pip install gunicorn
+
+ENV DATABASE_HOST db
+ENV DATABASE_PORT 3306
+ENV DATABASE_NAME orion
+ENV DATABASE_USER root
+ENV DATABASE_PASSWORD orion
+ENV PYTHONPATH "/"
+
+EXPOSE 80
+
+CMD make init-db && gunicorn --bind 0.0.0.0:80 -w 4 orion.server:app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:2.7.16-slim
+FROM python:2.7-buster
 MAINTAINER Kevin Lin <developer@kevinlin.info>
 
-RUN apt-get update && apt-get install -y wget unzip python-dev libmariadb-dev-compat gcc build-essential && pip install gunicorn
+RUN pip install gunicorn
 COPY . /
 RUN pip install -r requirements.txt 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:2.7.16-slim
 MAINTAINER Kevin Lin <developer@kevinlin.info>
 
 RUN apt-get update && apt-get install -y wget unzip python-dev default-libmysqlclient-dev gcc build-essential && pip install gunicorn
-RUN pwd && ls && pip install -r requirements.txt 
+COPY . /
+RUN pip install -r requirements.txt 
 
 ENV DATABASE_HOST db
 ENV DATABASE_PORT 3306

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:2.7.16-slim
 MAINTAINER Kevin Lin <developer@kevinlin.info>
 
-RUN apt-get update && apt-get install -y wget unzip python-dev default-libmysqlclient-dev gcc build-essential && pip install gunicorn
+RUN apt-get update && apt-get install -y wget unzip python-dev libmysqlclient-dev gcc build-essential && pip install gunicorn
 COPY . /
 RUN pip install -r requirements.txt 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:2.7.16-slim
 MAINTAINER Kevin Lin <developer@kevinlin.info>
 
-RUN apt-get update && apt-get install -y wget unzip python-dev libmysqlclient-dev gcc build-essential && pip install gunicorn
+RUN apt-get update && apt-get install -y wget unzip python-dev libmariadb-dev-compat gcc build-essential && pip install gunicorn
 COPY . /
 RUN pip install -r requirements.txt 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:2.7.16-slim
 MAINTAINER Kevin Lin <developer@kevinlin.info>
 
-RUN apt-get update && apt-get install -y wget unzip python-dev default-libmysqlclient-dev gcc build-essential && pip install -r requirements.txt && pip install gunicorn
+RUN apt-get update && apt-get install -y wget unzip python-dev default-libmysqlclient-dev gcc build-essential && pip install gunicorn
+RUN pwd && ls && pip install -r requirements.txt 
 
 ENV DATABASE_HOST db
 ENV DATABASE_PORT 3306


### PR DESCRIPTION
This allows to build automatically images from the source repo, and to offer pre-built images to users.
After merging, you can add the repo to docker hub for automated building, like I did there :
https://cloud.docker.com/repository/docker/cosme/orion-server
This provides the best experience for users.