### PR TITLE
orion/handlers/publish_handler: fix server error on empty payloads

### DIFF
--- a/orion/handlers/publish_handler.py
+++ b/orion/handlers/publish_handler.py
@@ -65,6 +65,15 @@ class PublishHandler(BaseHandler):
     path = '/api/publish'
 
     def run(self, *args, **kwargs):
+        # Owntracks will send zero-length HTTP payloads after a friend has been
+        # deleted in app, in order to clear the data off the MQTT broker.
+        # No further way points will be transmitted until those payloads are
+        # accepted. Therefore, simply ignore those gracefully.
+        #
+        # Ref: https://github.com/owntracks/ios/issues/580#issuecomment-495276821
+        if '_type' not in  self.data:
+          return self.success(status=200)
+
         # Sometimes the client tries to send a reportLocation cmd. If server
         # responds with non-200, all further location updates get backed up behind it.
         # Handle with empty 200 response


### PR DESCRIPTION
Owntracks will send zero-length HTTP payloads after a friend has been
deleted in app, in order to clear the data off the MQTT broker.
No further way points will be transmitted until those payloads are
accepted. Therefore, simply ignore those gracefully.

Ref: https://github.com/owntracks/ios/issues/580#issuecomment-495276821

```
[2020-01-26 09:55:56,550] ERROR in app: Exception on /api/publish [POST]
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/site-packages/flask_cors/extension.py", line 161, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/orion/orion/app.py", line 38, in handler_wrapper
    resp_json, status = handler.run(*args, **kwargs)
  File "/orion/orion/handlers/publish_handler.py", line 71, in run
    if self.data['_type'] == 'cmd' and self.data['action'] == 'reportLocation':
KeyError: '_type'
```

I also have tcpdumps if you'd like, omitted because the issue seems pretty clear already.