### PR TITLE
Add support for iOS' OwnTracks fields

### DIFF
--- a/orion/handlers/publish_handler.py
+++ b/orion/handlers/publish_handler.py
@@ -90,12 +90,18 @@ class PublishHandler(BaseHandler):
             device=device,
             latitude=lat,
             longitude=lon,
+            altitude=self.data.get('alt', 0),
             accuracy=self.data.get('acc'),
+            accuracy_alt=self.data.get('vac', 0),
             battery=self.data.get('batt'),
+            battery_status=self.data.get('bs', 0),
             trigger=self.data.get('t'),
             connection=self.data.get('conn'),
             tracker_id=self.data.get('tid'),
             address=address,
+            angle=self.data.get('cog', 0),
+            pressure=self.data.get('p', 0),
+            velocity=self.data.get('vel', 0)
         )
 
         with self.ctx.metrics_latency.profile('db.write_ms'):

--- a/orion/models/location.py
+++ b/orion/models/location.py
@@ -19,15 +19,20 @@ class Location(BaseModel):
     timestamp = Column(Integer)
     user = Column(String(256), index=True)
     device = Column(String(256), index=True)
-    # Retain 10 decimal points for at most 3 integer places
     latitude = Column(Numeric(precision=13, scale=10, asdecimal=False))
     longitude = Column(Numeric(precision=13, scale=10, asdecimal=False))
+    altitude = Column(Integer, default=None)
     accuracy = Column(Integer, default=None)
+    accuracy_alt = Column(Integer, default=None)
     battery = Column(Integer, default=None)
+    battery_status = Column(Integer, default=None)
     trigger = Column(String(1), default=None)
     connection = Column(String(1), default=None)
     tracker_id = Column(String(2), default=None)
     address = Column(String(256), default=None)
+    angle = Column(Integer, default=None)
+    pressure = Column(Numeric(precision=19, scale=16, asdecimal=False))
+    velocity = Column(Integer, default=None)
 
     def __init__(
         self,
@@ -36,12 +41,18 @@ class Location(BaseModel):
         device,
         latitude,
         longitude,
+        altitude,
         accuracy,
+        accuracy_alt,
         battery,
+        battery_status,
         trigger,
         connection,
         tracker_id,
         address,
+        angle,
+        pressure,
+        velocity,
     ):
         """
         Create a location report entry.
@@ -51,25 +62,37 @@ class Location(BaseModel):
         :param device: User's device name.
         :param latitude: Latitude, as a float.
         :param longitude: Longitude, as a float.
+        :param altitude: Altitude over sea level in meters, as an integer.
         :param accuracy: Accuracy in meters.
+        :param accuracy_alt: Accuracy of Altitude in meters.
         :param battery: Device's battery percentage at the time of reporting.
+        :param battery_status: Single-digit code representing the battery status.
         :param trigger: Single-character code representing the trigger mechanism.
         :param connection: Single-character code representing the network connection type when the
                            report was created.
         :param tracker_id: Client-specified tracker ID.
         :param address: Reverse-geocoded address of this coordinate.
+        :param angle: Course over ground in degrees.
+        :param pressure: Barometric pressure in kPA as a float.
+        :param velocity: Velocity in km/h as an integer.
         """
         self.timestamp = timestamp
         self.user = user
         self.device = device
         self.latitude = latitude
         self.longitude = longitude
+        self.altitude = altitude
         self.accuracy = accuracy
+        self.accuracy_alt = accuracy_alt
         self.battery = battery
+        self.battery_status = battery_status
         self.trigger = trigger
         self.connection = connection
         self.tracker_id = tracker_id
         self.address = address
+        self.angle = angle
+        self.pressure = pressure
+        self.velocity = velocity
 
     def serialize(self, fields=()):
         """
@@ -86,11 +109,17 @@ class Location(BaseModel):
             'device': self.device,
             'latitude': self.latitude,
             'longitude': self.longitude,
+            'altitude': self.altitude,
             'accuracy': self.accuracy,
+            'accuracy_alt': self.accuracy_alt,
             'battery': self.battery,
+            'battery_status': self.battery_status,
             'connection': self.connection,
             'tracker_id': self.tracker_id,
             'address': self.address,
+            'angle': self.angle,
+            'pressure': self.pressure,
+            'velocity': self.velocity
         }
 
         return {


### PR DESCRIPTION
Fields are defaulted to conserve Android compatibility. Note that Altitude and Velocity are also reported by Android.